### PR TITLE
activate integration-tests

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservices/DevServicesConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservices/DevServicesConfig.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.wiremock.devservices;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -29,8 +30,8 @@ public class DevServicesConfig {
      * <p>
      * If not defined, the port will be 8089
      */
-    @ConfigItem(name = "port", defaultValue = "8089")
-    public int port;
+    @ConfigItem(name = "port")
+    public Optional<Integer> port;
 
     /**
      * Devservice name. default to wiremock-server

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.quarkiverse.wiremock</groupId>
         <artifactId>quarkus-wiremock-parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.3-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-wiremock-integration-tests</artifactId>
     <name>Wiremock - Integration Tests</name>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>io.quarkiverse.wiremock</groupId>
             <artifactId>quarkus-wiremock-test</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/src/main/java/io/quarkiverse/wiremock/it/WiremockDevResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/wiremock/it/WiremockDevResource.java
@@ -10,6 +10,8 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
@@ -20,17 +22,22 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 public class WiremockDevResource {
     @Inject
     Vertx vertx;
+
     @Context
     private UriInfo uriInfo;
+
     @Context
     private HttpHeaders headers;
+
+    @ConfigProperty(name = "quarkus.wiremock.devservices.port")
+    String wireMockPort;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public Uni<String> hello() {
         WebClient client = WebClient.create(vertx);
 
-        return client.getAbs("http://localhost:8089/wiremock-dev").send().onItem()
+        return client.getAbs(String.format("http://localhost:%s/wiremock-dev", wireMockPort)).send().onItem()
                 .transform(HttpResponse::bodyAsString);
     }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/wiremock/it/WiremockDevResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/wiremock/it/WiremockDevResourceTest.java
@@ -10,12 +10,11 @@ import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.quarkiverse.wiremock.test.InjectWireMock;
-import io.quarkiverse.wiremock.test.WireMockServerTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkiverse.wiremock.test.WithWireMockServer;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(WireMockServerTestResource.class)
+@WithWireMockServer
 public class WiremockDevResourceTest {
 
     @InjectWireMock
@@ -25,7 +24,8 @@ public class WiremockDevResourceTest {
     public void testHelloEndpoint() {
         Assertions.assertNotNull(wiremock);
         wiremock.register(
-                get(urlEqualTo("/wiremock-dev")).willReturn(aResponse().withStatus(200).withBody("Hello wiremock-dev")));
+                get(urlPathEqualTo("/wiremock-dev")).willReturn(aResponse().withStatus(200)
+                        .withBody("Hello wiremock-dev")));
 
         given()
                 .when().get("/wiremock-dev")

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <module>runtime</module>
     <module>docs</module>
     <module>test</module>
+    <module>integration-tests</module>
   </modules>
   <properties>
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
@@ -38,7 +39,7 @@
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
+        <artifactId>wiremock-jre8-standalone</artifactId>
         <version>${wiremock.version}</version>
       </dependency>
     </dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -15,7 +15,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.wiremock</groupId>

--- a/test/src/main/java/io/quarkiverse/wiremock/test/WireMockServerTestResource.java
+++ b/test/src/main/java/io/quarkiverse/wiremock/test/WireMockServerTestResource.java
@@ -8,9 +8,10 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.quarkiverse.wiremock.runtime.WireMockServerConfig;
 import io.quarkus.test.common.DevServicesContext;
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
 
-public class WireMockServerTestResource implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+public class WireMockServerTestResource
+        implements QuarkusTestResourceConfigurableLifecycleManager<WithWireMockServer>, DevServicesContext.ContextAware {
 
     private static final Logger LOGGER = Logger.getLogger(WireMockServerTestResource.class);
     WireMock WIREMOCK;
@@ -36,9 +37,9 @@ public class WireMockServerTestResource implements QuarkusTestResourceLifecycleM
     public void setIntegrationTestContext(DevServicesContext context) {
         LOGGER.debug("setIntegrationTest");
         Map<String, String> devContext = context.devServicesProperties();
-        int port = Integer.parseInt(devContext.get(WireMockServerConfig.PORT));
         String host = "localhost";
         try {
+            int port = Integer.parseInt(devContext.get(WireMockServerConfig.PORT));
             WIREMOCK = new WireMock(host, port);
         } catch (Exception ex) {
             LOGGER.error("WireMock not found, it should be run from devservices.");

--- a/test/src/main/java/io/quarkiverse/wiremock/test/WithWireMockServer.java
+++ b/test/src/main/java/io/quarkiverse/wiremock/test/WithWireMockServer.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.wiremock.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(value = WireMockServerTestResource.class, restrictToAnnotatedClass = true)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+public @interface WithWireMockServer {
+}


### PR DESCRIPTION
- add integration-tests to the list of module
- some refactoring
- let port be optional to have wiremock dynamically pick one
- introduce `@WithWireMockServer` annotation
- use jre8-standalone (I had some dependency errors with the classic package) and quarkus is using this package too