### PR TITLE
feat: upgrade to WireMock 3

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -19,8 +19,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.2.6.Final</quarkus.version>
-    <wiremock.version>2.35.1</wiremock.version>
+    <wiremock.version>3.2.0</wiremock.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -40,8 +40,8 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock</artifactId>
         <version>${wiremock.version}</version>
       </dependency>
     </dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -19,8 +19,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Upgrades Wiremock to the new v3 with updated maven coordinates. See https://github.com/wiremock/wiremock/releases

And enables the global response templating with a config key.