### PR TITLE
feat: switch to wiremock-jre8-standalone

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockBasicTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockBasicTest.java
@@ -4,8 +4,8 @@ import static io.quarkiverse.wiremock.devservice.TestUtil.APP_PROPERTIES;
 import static io.quarkiverse.wiremock.devservice.WireMockDevServiceConfig.PORT;
 import static io.quarkiverse.wiremock.devservice.WireMockDevServiceConfig.PREFIX;
 import static org.hamcrest.Matchers.is;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
 
-import org.eclipse.jetty.server.Response;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -24,14 +24,14 @@ class WireMockBasicTest {
     @Test
     void testWireMockMappingsFolder() {
         final int port = ConfigProvider.getConfig().getValue(PREFIX + "." + PORT, Integer.class);
-        RestAssured.when().get(String.format("http://localhost:%d/wiremock", port)).then().statusCode(Response.SC_OK)
+        RestAssured.when().get(String.format("http://localhost:%d/wiremock", port)).then().statusCode(OK)
                 .body(is("Everything was just fine!"));
     }
 
     @Test
     void testTemplatingDisabled() {
         final int port = ConfigProvider.getConfig().getValue(PREFIX + "." + PORT, Integer.class);
-        RestAssured.when().get(String.format("http://localhost:%d/template", port)).then().statusCode(Response.SC_OK)
+        RestAssured.when().get(String.format("http://localhost:%d/template", port)).then().statusCode(OK)
                 .body(is("Everything was just fine from {{ request.port }}!"));
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockTemplatingTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockTemplatingTest.java
@@ -3,8 +3,8 @@ package io.quarkiverse.wiremock.devservice;
 import static io.quarkiverse.wiremock.devservice.WireMockDevServiceConfig.PORT;
 import static io.quarkiverse.wiremock.devservice.WireMockDevServiceConfig.PREFIX;
 import static org.hamcrest.Matchers.is;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
 
-import org.eclipse.jetty.server.Response;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -25,7 +25,7 @@ class WireMockTemplatingTest {
     @Test
     void testTemplatingEnabled() {
         final int port = ConfigProvider.getConfig().getValue(PREFIX + "." + PORT, Integer.class);
-        RestAssured.when().get(String.format("http://localhost:%d/template", port)).then().statusCode(Response.SC_OK)
+        RestAssured.when().get(String.format("http://localhost:%d/template", port)).then().statusCode(OK)
                 .body(is(String.format("Everything was just fine from %d!", port)));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
+        <artifactId>wiremock-jre8-standalone</artifactId>
         <version>${wiremock.version}</version>
       </dependency>
     </dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
WireMock pulls in a bunch of (vulnerable) dependencies that we don't need, so simplifying the dependency tree by switching to the standalone version, see https://wiremock.org/docs/standalone/

Quarkus also uses the standalone version in their tests, see for example https://github.com/quarkusio/quarkus/blob/7dcbe6793d431ce140131550775c406ea9e2d74e/extensions/resteasy-reactive/rest-client-reactive/deployment/pom.xml#L73

I'll do the same for the main branch next.