### PR TITLE
fix: render WireMock Dev Service in Dev UI

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,7 +1,7 @@
 ---
 name: "WireMock"
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-description: WireMock DevService for tests and local development
+description: WireMock Dev Service for tests and local development
 metadata:
   short-name: "wiremock"
   keywords:


### PR DESCRIPTION
This PR integrates the WireMock Dev Service into the Quarkus Dev UI properly.