### PR TITLE
WireMock config changes are taken into account for live-reload (dev mode only)

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
@@ -6,6 +6,13 @@ import static java.lang.String.format;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 
@@ -13,6 +20,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
+import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -20,6 +28,7 @@ import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServiceDescriptionBuildItem;
@@ -30,6 +39,8 @@ class WireMockServerProcessor {
     private static final Logger LOGGER = Logger.getLogger(WireMockServerProcessor.class);
     private static final String FEATURE_NAME = "wiremock";
     private static final String DEV_SERVICE_NAME = "WireMock";
+    private static final String MAPPINGS = "mappings";
+    private static final String FILES = "__files";
     private static final int MIN_PORT = 1025;
     private static final int MAX_PORT = 65535;
     static volatile RunningDevService devService;
@@ -69,8 +80,17 @@ class WireMockServerProcessor {
 
     @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class })
     @Consume(DevServicesResultBuildItem.class)
-    DevServiceDescriptionBuildItem renderDevServiceDevUICard(WireMockServerBuildTimeConfig config) {
+    DevServiceDescriptionBuildItem renderDevServiceDevUICard() {
         return new DevServiceDescriptionBuildItem(DEV_SERVICE_NAME, null, devService.getConfig());
+    }
+
+    @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class, IsDevelopment.class })
+    void watchWireMockConfigFiles(WireMockServerBuildTimeConfig config,
+            BuildProducer<HotDeploymentWatchedFileBuildItem> items) {
+        listFiles(Paths.get(config.filesMapping(), MAPPINGS), Paths.get(config.filesMapping(), FILES)).forEach(file -> {
+            LOGGER.debugf("Watching [%s] for hot deployment!", file);
+            items.produce(new HotDeploymentWatchedFileBuildItem(file));
+        });
     }
 
     private static RunningDevService startWireMockDevService(WireMockServerBuildTimeConfig config) {
@@ -83,15 +103,13 @@ class WireMockServerProcessor {
         server.start();
         LOGGER.debugf("WireMock server listening on port [%s]", server.port());
 
-        return new RunningDevService(DEV_SERVICE_NAME, null, server::shutdown, PORT,
-                String.valueOf(server.port()));
+        return new RunningDevService(DEV_SERVICE_NAME, null, server::shutdown, PORT, String.valueOf(server.port()));
     }
 
     private static synchronized void stopWireMockDevService() {
         try {
             if (devService != null) {
-                LOGGER.debugf("Stopping WireMock server running on port %s",
-                        devService.getConfig().get(PORT));
+                LOGGER.debugf("Stopping WireMock server running on port %s", devService.getConfig().get(PORT));
                 devService.close();
             }
         } catch (IOException e) {
@@ -108,6 +126,20 @@ class WireMockServerProcessor {
         }
         final int port = config.port().getAsInt();
         return port < MIN_PORT || port > MAX_PORT;
+    }
+
+    private static Set<String> listFiles(Path... dirs) {
+        return Arrays.stream(dirs).filter(Files::isDirectory).map(WireMockServerProcessor::fileWalk)
+                .flatMap(Set::stream).collect(Collectors.toSet());
+    }
+
+    private static Set<String> fileWalk(Path start) {
+        try (Stream<Path> stream = Files.walk(start)) {
+            return stream.filter(Files::isRegularFile).map(Path::toAbsolutePath).map(Path::toString)
+                    .collect(Collectors.toSet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
 }

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/ConfigProviderResource.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/ConfigProviderResource.java
@@ -1,22 +1,33 @@
 package io.quarkiverse.wiremock.devservice;
 
+import static io.quarkiverse.wiremock.devservice.ConfigProviderResource.BASE_URL;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
-@Path("/quarkus/wiremock")
+@Path(BASE_URL)
 @ApplicationScoped
 class ConfigProviderResource {
 
-    @Path("/devservices/config")
+    static final String BASE_URL = "/quarkus/wiremock/devservices";
+
     @GET
+    @Path("/reload")
+    public Response reload() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/config")
     @Produces(MediaType.TEXT_PLAIN)
-    public String getConfigValue(@QueryParam("name") String propertyName) {
+    public String getConfigValue(@QueryParam("propertyName") String propertyName) {
         return ConfigProvider.getConfig().getValue(propertyName, String.class);
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockBasicDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockBasicDevModeTest.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.wiremock.devservice;
 
+import static io.quarkiverse.wiremock.devservice.ConfigProviderResource.BASE_URL;
+import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
+import static java.lang.String.format;
 import static org.hamcrest.Matchers.is;
 import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
 
@@ -12,18 +15,19 @@ import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
 
 @SuppressWarnings("java:S5786")
-public class WireMockDevModeTest {
+public class WireMockBasicDevModeTest {
 
     private static final String APP_PROPERTIES = "application-static-port.properties";
 
     @RegisterExtension
     static final QuarkusDevModeTest DEV_MODE_TEST = new QuarkusDevModeTest().setArchiveProducer(
-            () -> ShrinkWrap.create(JavaArchive.class)
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(ConfigProviderResource.class)
                     .addAsResource(APP_PROPERTIES, "application.properties"));
 
     @Test
     void testJsonMappingFilesRecognition() {
-        RestAssured.when().get("http://localhost:50200/wiremock").then().statusCode(OK)
+        String port = RestAssured.get(format("%s/config?propertyName=%s", BASE_URL, PORT)).then().extract().asString();
+        RestAssured.when().get(format("http://localhost:%s/basic", port)).then().statusCode(OK)
                 .body(is("Everything was just fine!"));
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockBasicTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockBasicTest.java
@@ -24,7 +24,7 @@ class WireMockBasicTest {
     @Test
     void testWireMockMappingsFolder() {
         final int port = ConfigProvider.getConfig().getValue(PORT, Integer.class);
-        RestAssured.when().get(String.format("http://localhost:%d/wiremock", port)).then().statusCode(OK)
+        RestAssured.when().get(String.format("http://localhost:%d/basic", port)).then().statusCode(OK)
                 .body(is("Everything was just fine!"));
     }
 

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockLiveReloadTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockLiveReloadTest.java
@@ -1,13 +1,21 @@
 package io.quarkiverse.wiremock.devservice;
 
+import static io.quarkiverse.wiremock.devservice.ConfigProviderResource.BASE_URL;
+import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.FILES_MAPPING;
 import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -16,6 +24,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 
 /**
  * Write your dev mode tests here - see the <a href="https://quarkus.io/guides/writing-extensions#testing-hot-reload">testing
@@ -23,11 +32,9 @@ import io.restassured.RestAssured;
  */
 @SuppressWarnings("java:S5786")
 public class WireMockLiveReloadTest {
-    private static final String BASE_URL = "/quarkus/wiremock/devservices";
     private static final int TARGET_STATIC_WIREMOCK_PORT = 50000;
     private static final String APP_PROPERTIES = "application.properties";
 
-    // Start hot reload (DevMode) test with your extension loaded
     @RegisterExtension
     static final QuarkusDevModeTest DEV_MODE_TEST = new QuarkusDevModeTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class).addClass(ConfigProviderResource.class)
@@ -36,21 +43,76 @@ public class WireMockLiveReloadTest {
     @Test
     void testPortModificationViaLiveReload() {
 
-        assertFalse(isInUse(TARGET_STATIC_WIREMOCK_PORT),
-                "Port" + TARGET_STATIC_WIREMOCK_PORT + " is already in use!");
+        Given.portIsNotInUse(TARGET_STATIC_WIREMOCK_PORT);
 
-        // add port configuration to the properties file
-        DEV_MODE_TEST.modifyResourceFile(APP_PROPERTIES,
-                s -> s.concat(System.lineSeparator() + PORT + "=" + TARGET_STATIC_WIREMOCK_PORT));
+        When.addApplicationProperty(System.lineSeparator() + PORT + "=" +
+                TARGET_STATIC_WIREMOCK_PORT); // add port configuration to the properties file
+        When.callConfigProvider(PORT).then().body(equalTo(String.valueOf(TARGET_STATIC_WIREMOCK_PORT)));
 
-        // Currently, the live-reload can only be triggered via a http call.
-        // See https://github.com/quarkiverse/quarkus-wiremock/issues/69 for more details.
-        // This will be enhanced with the next development iteration.
-        RestAssured.get(format("%s/config?name=%s", BASE_URL, PORT)).then()
-                .body(equalTo(String.valueOf(TARGET_STATIC_WIREMOCK_PORT)));
+        Then.portIsInUse(TARGET_STATIC_WIREMOCK_PORT);
+    }
 
-        assertTrue(isInUse(TARGET_STATIC_WIREMOCK_PORT),
-                "WireMock Dev Service doesn't listen on port " + TARGET_STATIC_WIREMOCK_PORT);
+    @Test
+    void testWireMockConfigChangeHotDeployment() throws IOException {
+
+        var tempDir = Files.createTempDirectory(Path.of("target"), "wiremock-");
+        var wireMockConfig = Given.wireMockConfigFile(tempDir); // create temporary WireMock config
+
+        // specify temp dir as files-mapping location
+        When.addApplicationProperty(System.lineSeparator() + FILES_MAPPING + "=target/" + tempDir.getFileName());
+        When.triggerHttpLiveReload(); // --> At this point, Quarkus watches the new config file
+        When.callWireMock().then().statusCode(OK).body(is("Modify me at runtime!"));
+
+        When.modifyResponseBody(wireMockConfig);
+        When.callWireMock().then().statusCode(OK).body(is("Live reload rockz!"));
+    }
+
+    private static class Given {
+
+        private static Path wireMockConfigFile(Path rootLocation) throws IOException {
+            var mapLocation = Paths.get(rootLocation.toFile().getAbsolutePath(), "mappings");
+            Files.createDirectories(mapLocation);
+            var configFile = Paths.get(mapLocation.toFile().getAbsolutePath(), "modify.json");
+            Files.write(configFile,
+                    "{\"request\":{\"method\":\"GET\",\"url\": \"/modify\"},\"response\":{\"status\": 200,\"body\":\"Modify me at runtime!\"}}"
+                            .getBytes(
+                                    StandardCharsets.UTF_8));
+            return configFile;
+        }
+
+        private static void portIsNotInUse(int port) {
+            assertFalse(isInUse(port), "Port " + port + " is already in use!");
+        }
+    }
+
+    private static class When {
+        private static void triggerHttpLiveReload() {
+            RestAssured.get(format("%s/reload", BASE_URL));
+        }
+
+        private static Response callWireMock() {
+            return RestAssured.when().get(format("http://localhost:%d/modify", getDynamicPort()));
+        }
+
+        private static Response callConfigProvider(String propertyName) {
+            return RestAssured.get(format("%s/config?propertyName=%s", BASE_URL, propertyName));
+        }
+
+        private static void addApplicationProperty(String property) {
+            DEV_MODE_TEST.modifyResourceFile(APP_PROPERTIES, s -> s.concat(property));
+        }
+
+        private static void modifyResponseBody(Path configFile) throws IOException {
+            Files.writeString(configFile,
+                    Files.readString(configFile).replace("Modify me at runtime!", "Live reload rockz!"));
+        }
+    }
+
+    private static class Then {
+
+        private static void portIsInUse(int port) {
+            assertTrue(isInUse(port), "No Service is listening on port " + port);
+        }
     }
 
     private static boolean isInUse(int port) {
@@ -59,5 +121,9 @@ public class WireMockLiveReloadTest {
         } catch (IOException e) {
             return true;
         }
+    }
+
+    private static int getDynamicPort() {
+        return Integer.parseInt(When.callConfigProvider(PORT).then().extract().asString());
     }
 }

--- a/deployment/src/test/resources/mappings/basic.json
+++ b/deployment/src/test/resources/mappings/basic.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/wiremock"
+    "url": "/basic"
   },
   "response": {
     "status": 200,


### PR DESCRIPTION
This PR makes the `Live Reload` feature of `Quarkus Dev Mode` aware of `WireMock` config changes. However, the implementation has some limitations:
* The file modification gets only recognized after a http request. --> Fits naturally to the WireMock usage model
* A manual app restart is required when adding a new config file at runtime