### PR TITLE
Add config option that enables Service Loading

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerBuildTimeConfig.java
@@ -45,4 +45,13 @@ public interface WireMockServerBuildTimeConfig {
      */
     @WithDefault("false")
     boolean globalResponseTemplating();
+
+    /**
+     * Control whether WireMock Extension <a href=
+     * "https://wiremock.org/docs/extending-wiremock/#extension-registration-via-service-loading">service
+     * loading</a>,
+     * is enabled
+     */
+    @WithDefault("false")
+    boolean extensionScanningEnabled();
 }

--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
@@ -96,7 +96,8 @@ class WireMockServerProcessor {
     private static RunningDevService startWireMockDevService(WireMockServerBuildTimeConfig config) {
 
         final WireMockConfiguration configuration = options().usingFilesUnderDirectory(config.filesMapping())
-                .globalTemplating(config.globalResponseTemplating());
+                .globalTemplating(config.globalResponseTemplating())
+                .extensionScanningEnabled(config.extensionScanningEnabled());
         config.port().ifPresentOrElse(configuration::port, configuration::dynamicPort);
 
         final WireMockServer server = new WireMockServer(configuration);

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/CustomTransformer.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/CustomTransformer.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.wiremock.devservice;
+
+import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformerV2;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+
+public class CustomTransformer implements ResponseDefinitionTransformerV2 {
+    @Override
+    public ResponseDefinition transform(ServeEvent serveEvent) {
+        ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
+        responseDefinition.getTransformerParameters().put("custom", "good");
+        return responseDefinition;
+    }
+
+    @Override
+    public String getName() {
+        return "custom-transformer";
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WiremockExtensionServiceLoadingDisabled.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WiremockExtensionServiceLoadingDisabled.java
@@ -1,0 +1,33 @@
+
+package io.quarkiverse.wiremock.devservice;
+
+import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
+import static org.hamcrest.Matchers.is;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class WiremockExtensionServiceLoadingDisabled {
+
+    private static final String APP_PROPERTIES = "application-extension-loading-disabled.properties";
+
+    @RegisterExtension
+    static final QuarkusUnitTest UNIT_TEST = new QuarkusUnitTest().withConfigurationResource(APP_PROPERTIES)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(CustomTransformer.class)
+                    .addAsResource("META-INF/services/com.github.tomakehurst.wiremock.extension.Extension"));
+
+    @Test
+    void testExtensionScanningEnabled() {
+        final int port = ConfigProvider.getConfig().getValue(PORT, Integer.class);
+        RestAssured.when().get(String.format("http://localhost:%d/custom-variable", port)).then().statusCode(OK)
+                .body(is("Response is test!"));
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WiremockExtensionServiceLoadingEnabled.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WiremockExtensionServiceLoadingEnabled.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.wiremock.devservice;
+
+import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
+import static org.hamcrest.Matchers.is;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class WiremockExtensionServiceLoadingEnabled {
+
+    private static final String APP_PROPERTIES = "application-extension-loading-enabled.properties";
+
+    @RegisterExtension
+    static final QuarkusUnitTest UNIT_TEST = new QuarkusUnitTest().withConfigurationResource(APP_PROPERTIES)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(CustomTransformer.class)
+                    .addAsResource("META-INF/services/com.github.tomakehurst.wiremock.extension.Extension"));
+
+    @Test
+    void testExtensionScanningEnabled() {
+        final int port = ConfigProvider.getConfig().getValue(PORT, Integer.class);
+        RestAssured.when().get(String.format("http://localhost:%d/custom-variable", port)).then().statusCode(OK)
+                .body(is("Response is good!"));
+    }
+}

--- a/deployment/src/test/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
+++ b/deployment/src/test/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
@@ -1,0 +1,1 @@
+io.quarkiverse.wiremock.devservice.CustomTransformer

--- a/deployment/src/test/resources/application-extension-loading-disabled.properties
+++ b/deployment/src/test/resources/application-extension-loading-disabled.properties
@@ -1,0 +1,2 @@
+quarkus.wiremock.devservices.global-response-templating=true
+quarkus.wiremock.devservices.extension-scanning-disabled=true

--- a/deployment/src/test/resources/application-extension-loading-enabled.properties
+++ b/deployment/src/test/resources/application-extension-loading-enabled.properties
@@ -1,0 +1,2 @@
+quarkus.wiremock.devservices.global-response-templating=true
+quarkus.wiremock.devservices.extension-scanning-enabled=true

--- a/deployment/src/test/resources/mappings/custom-template.json
+++ b/deployment/src/test/resources/mappings/custom-template.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/custom-variable"
+  },
+  "response": {
+    "status": 200,
+    "body": "Response is {{ parameters.custom }}!",
+    "transformers": ["custom-transformer"],
+    "transformerParameters": {
+      "custom": "test"
+    }
+  }
+}


### PR DESCRIPTION
The context of this is [this](https://github.com/quarkiverse/quarkus-langchain4j/issues/446) issue where I would like to move away for custom WireMock handling to using this extension.

However in order to do so, I would need some custom code that can set parameter templates and for that I need for a custom WireMock Extension to be loaded.