### PR TITLE
Allow resource loading to be done from the Classpath

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerBuildTimeConfig.java
@@ -33,7 +33,8 @@ public interface WireMockServerBuildTimeConfig {
     OptionalInt port();
 
     /**
-     * Path to the WireMock configuration files
+     * Path to the WireMock configuration files.
+     * If this starts with {@code classpath:} then files will be looked up on the classpath instead of the filesystem
      */
     @WithDefault("src/test/resources")
     String filesMapping();
@@ -45,4 +46,16 @@ public interface WireMockServerBuildTimeConfig {
      */
     @WithDefault("false")
     boolean globalResponseTemplating();
+
+    default boolean isClasspathFilesMapping() {
+        return filesMapping().startsWith("classpath:");
+    }
+
+    default String effectiveFileMapping() {
+        if (isClasspathFilesMapping()) {
+            int index = filesMapping().indexOf(':');
+            return filesMapping().substring(index + 1);
+        }
+        return filesMapping();
+    }
 }

--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import org.jboss.logging.Logger;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.arc.deployment.ValidationPhaseBuildItem.ValidationErrorBuildItem;
@@ -87,17 +88,28 @@ class WireMockServerProcessor {
     @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class, IsDevelopment.class })
     void watchWireMockConfigFiles(WireMockServerBuildTimeConfig config,
             BuildProducer<HotDeploymentWatchedFileBuildItem> items) {
-        listFiles(Paths.get(config.filesMapping(), MAPPINGS), Paths.get(config.filesMapping(), FILES)).forEach(file -> {
-            LOGGER.debugf("Watching [%s] for hot deployment!", file);
-            items.produce(new HotDeploymentWatchedFileBuildItem(file));
-        });
+
+        if (!config.isClasspathFilesMapping()) {
+            listFiles(Paths.get(config.effectiveFileMapping(), MAPPINGS), Paths.get(config.effectiveFileMapping(), FILES))
+                    .forEach(file -> {
+                        LOGGER.debugf("Watching [%s] for hot deployment!", file);
+                        items.produce(new HotDeploymentWatchedFileBuildItem(file));
+                    });
+        }
     }
 
     private static RunningDevService startWireMockDevService(WireMockServerBuildTimeConfig config) {
 
-        final WireMockConfiguration configuration = options().usingFilesUnderDirectory(config.filesMapping())
+        final WireMockConfiguration configuration = options()
                 .globalTemplating(config.globalResponseTemplating());
         config.port().ifPresentOrElse(configuration::port, configuration::dynamicPort);
+        if (config.isClasspathFilesMapping()) {
+            configuration
+                    .fileSource(new ClasspathFileSource(Thread.currentThread().getContextClassLoader(),
+                            config.effectiveFileMapping()));
+        } else {
+            configuration.usingFilesUnderDirectory(config.effectiveFileMapping());
+        }
 
         final WireMockServer server = new WireMockServer(configuration);
         server.start();

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockTemplatingClasspathDevModeTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockTemplatingClasspathDevModeTest.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.wiremock.devservice;
+
+import static io.quarkiverse.wiremock.devservice.ConfigProviderResource.BASE_URL;
+import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.is;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+
+public class WireMockTemplatingClasspathDevModeTest {
+
+    private static final String APP_PROPERTIES = "application-templating-classpath.properties";
+
+    @RegisterExtension
+    static final QuarkusDevModeTest DEV_MODE_TEST = new QuarkusDevModeTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addClass(ConfigProviderResource.class)
+                    .addAsResource(APP_PROPERTIES, "application.properties")
+                    .addAsResource("other/mappings/cp.json"));
+
+    @Test
+    void testJsonMappingFilesRecognition() {
+        String port = RestAssured.get(format("%s/config?propertyName=%s", BASE_URL, PORT)).then().extract().asString();
+        RestAssured.when().get(format("http://localhost:%s/cp", port)).then().statusCode(OK)
+                .body(is(String.format("All good from %s!", port)));
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockTemplatingClasspathTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockTemplatingClasspathTest.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.wiremock.devservice;
+
+import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
+import static org.hamcrest.Matchers.is;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+class WireMockTemplatingClasspathTest {
+
+    private static final String APP_PROPERTIES = "application-templating-classpath.properties";
+
+    @RegisterExtension
+    static final QuarkusUnitTest UNIT_TEST = new QuarkusUnitTest().withConfigurationResource(APP_PROPERTIES)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("other/mappings/cp.json"));
+
+    @Test
+    void testTemplatingEnabled() {
+        final int port = ConfigProvider.getConfig().getValue(PORT, Integer.class);
+        RestAssured.when().get(String.format("http://localhost:%d/cp", port)).then().statusCode(OK)
+                .body(is(String.format("All good from %d!", port)));
+    }
+}

--- a/deployment/src/test/resources/application-templating-classpath.properties
+++ b/deployment/src/test/resources/application-templating-classpath.properties
@@ -1,0 +1,2 @@
+quarkus.wiremock.devservices.global-response-templating=true
+quarkus.wiremock.devservices.files-mapping=classpath:/other

--- a/deployment/src/test/resources/other/mappings/cp.json
+++ b/deployment/src/test/resources/other/mappings/cp.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/cp"
+  },
+  "response": {
+    "status": 200,
+    "body": "All good from {{ request.port }}!"
+  }
+}


### PR DESCRIPTION
The context of this is [this](https://github.com/quarkiverse/quarkus-langchain4j/issues/446) issue where I would like to move away for custom WireMock handling to using this extension.

However in order to do so, I plan to have a custom module that contains both resources and supporting code, and for that work I need to have the resources loadable from the classpath