### PR TITLE
configure rest client to proxy request via wiremock using DevServicesRestClientProxyProvider

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -24,12 +24,26 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-spi-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockProxyRestClientEnabled.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockProxyRestClientEnabled.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.wiremock.devservice;
+
+import java.util.function.BooleanSupplier;
+
+public class WireMockProxyRestClientEnabled implements BooleanSupplier {
+    WireMockServerBuildTimeConfig config;
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.proxyRestClient();
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerBuildTimeConfig.java
@@ -56,6 +56,12 @@ public interface WireMockServerBuildTimeConfig {
     @WithDefault("false")
     boolean extensionScanningEnabled();
 
+    /**
+     * Control whether rest client is automatically proxied via wiremock in dev and test mode.
+     */
+    @WithDefault("true")
+    boolean proxyRestClient();
+
     default boolean isClasspathFilesMapping() {
         return filesMapping().startsWith("classpath:");
     }

--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
 import static java.lang.String.format;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -26,11 +27,19 @@ import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
-import io.quarkus.deployment.builditem.*;
+import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.dev.devservices.DevServiceDescriptionBuildItem;
 import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
 import io.quarkus.logging.Log;
+import io.quarkus.rest.client.reactive.spi.DevServicesRestClientProxyProvider;
+import io.quarkus.rest.client.reactive.spi.RestClientHttpProxyBuildItem;
 import io.quarkus.runtime.configuration.ConfigurationException;
 
 class WireMockServerProcessor {
@@ -49,7 +58,9 @@ class WireMockServerProcessor {
     }
 
     @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class })
-    DevServicesResultBuildItem setup(LaunchModeBuildItem launchMode, LiveReloadBuildItem liveReload,
+    @Produce(WiremockStartedBuildItem.class)
+    void setup(
+            LaunchModeBuildItem launchMode, LiveReloadBuildItem liveReload,
             CuratedApplicationShutdownBuildItem shutdown, WireMockServerBuildTimeConfig config,
             BuildProducer<ValidationErrorBuildItem> configErrors) {
 
@@ -59,7 +70,7 @@ class WireMockServerProcessor {
             configErrors.produce(new ValidationErrorBuildItem(new ConfigurationException(
                     format("The specified port %d is not part of the permitted port range! Please specify a port between %d and %d.",
                             config.port().getAsInt(), MIN_PORT, MAX_PORT))));
-            return null;
+            return;
         }
 
         // register shutdown callback once
@@ -73,7 +84,15 @@ class WireMockServerProcessor {
         if (devService == null) {
             devService = startWireMockDevService(config);
         }
-        return devService.toBuildItem();
+    }
+
+    @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class })
+    @Consume(WiremockStartedBuildItem.class)
+    void provideDevServiceResult(BuildProducer<DevServicesResultBuildItem> result) {
+        // need to be done in a separate step to avoid cycle
+        if (devService != null) {
+            result.produce(devService.toBuildItem());
+        }
     }
 
     @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class })
@@ -93,6 +112,28 @@ class WireMockServerProcessor {
                         items.produce(new HotDeploymentWatchedFileBuildItem(file));
                     });
         }
+    }
+
+    @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class,
+            WireMockProxyRestClientEnabled.class })
+    @Consume(WiremockStartedBuildItem.class)
+    DevServicesRestClientProxyProvider.BuildItem provideRestClientProxyProvider() {
+        return new DevServicesRestClientProxyProvider.BuildItem(new DevServicesRestClientProxyProvider() {
+            @Override
+            public String name() {
+                return "wiremock";
+            }
+
+            @Override
+            public Closeable setup() {
+                return null;
+            }
+
+            @Override
+            public CreateResult create(RestClientHttpProxyBuildItem buildItem) {
+                return new CreateResult("localhost", Integer.parseInt(devService.getConfig().get(PORT)), null);
+            }
+        });
     }
 
     private static RunningDevService startWireMockDevService(WireMockServerBuildTimeConfig config) {

--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WiremockStartedBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WiremockStartedBuildItem.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.wiremock.devservice;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final public class WiremockStartedBuildItem extends SimpleBuildItem {
+
+}

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockProxyRestClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockProxyRestClientTest.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.wiremock.devservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class WireMockProxyRestClientTest {
+
+    private static final String APP_PROPERTIES = "application.properties";
+
+    @RegisterExtension
+    static final QuarkusUnitTest UNIT_TEST = new QuarkusUnitTest().withConfigurationResource(APP_PROPERTIES)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(QuarkusClient.class));
+
+    @Inject
+    @RestClient
+    QuarkusClient quarkusClient;
+
+    @Test
+    void testWireMockMappingsFolder() {
+
+        QuarkusClient.User result = quarkusClient.test();
+        assertEquals("John Doe", result.name());
+    }
+
+    @Path("/mock-rest-client")
+    @RegisterRestClient(baseUri = "https://imaginary-host.io/", configKey = "quarkus-client")
+    public interface QuarkusClient {
+
+        record User(String name, String email) {
+        }
+
+        @GET
+        @Consumes("application/json")
+        User test();
+    }
+}

--- a/deployment/src/test/resources/application.properties
+++ b/deployment/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.log.level=INFO
 quarkus.log.category."io.quarkiverse".level=DEBUG
+quarkus.rest-client."quarkus-client".enable-local-proxy=true

--- a/deployment/src/test/resources/mappings/rest-client.json
+++ b/deployment/src/test/resources/mappings/rest-client.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/mock-rest-client"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "name": "John Doe",
+      "email": "john.doe@quarkus.io"
+    }
+  }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-wiremock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-wiremock.adoc
@@ -114,6 +114,23 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-proxy-rest-client]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-proxy-rest-client[`quarkus.wiremock.devservices.proxy-rest-client`]##
+
+[.description]
+--
+Control whether rest client is automatically proxied via wiremock in dev and test mode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_PROXY_REST_CLIENT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_PROXY_REST_CLIENT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 |===
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-wiremock_quarkus.wiremock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-wiremock_quarkus.wiremock.adoc
@@ -114,6 +114,23 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-proxy-rest-client]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-proxy-rest-client[`quarkus.wiremock.devservices.proxy-rest-client`]##
+
+[.description]
+--
+Control whether rest client is automatically proxied via wiremock in dev and test mode.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_PROXY_REST_CLIENT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_PROXY_REST_CLIENT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 |===
 
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>quarkus-rest-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.wiremock</groupId>
             <artifactId>quarkus-wiremock</artifactId>
             <version>${project.version}</version>
@@ -101,8 +105,7 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
-                <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+                <quarkus.package.type>native</quarkus.package.type>
             </properties>
         </profile>
     </profiles>

--- a/integration-tests/src/main/java/io/quarkiverse/wiremock/devservice/QuarkusClient.java
+++ b/integration-tests/src/main/java/io/quarkiverse/wiremock/devservice/QuarkusClient.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.wiremock.devservice;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/mock-rest-client")
+@RegisterRestClient(baseUri = "https://imaginary-host.io/", configKey = "quarkus-client")
+public interface QuarkusClient {
+
+    record User(String name, String email) {
+    }
+
+    @GET
+    @Consumes("application/json")
+    User test();
+}

--- a/integration-tests/src/test/java/io/quarkiverse/wiremock/devservice/WiremockRestClientTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/wiremock/devservice/WiremockRestClientTest.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.wiremock.devservice;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@ConnectWireMock
+@QuarkusTest
+public class WiremockRestClientTest {
+
+    @Inject
+    @RestClient
+    QuarkusClient quarkusClient;
+    WireMock wiremock;
+
+    @Test
+    void testWireMockRestClientProxy() {
+        wiremock.register(get(urlEqualTo("/mock-rest-client"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\": \"John Doe\", \"email\": \"john.doe@quarkus.io\"}")));
+        QuarkusClient.User result = quarkusClient.test();
+        assertEquals("John Doe", result.name());
+    }
+}

--- a/integration-tests/src/test/resources/application.properties
+++ b/integration-tests/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 custom.config.wiremock.url=http://localhost:${quarkus.wiremock.devservices.port}/mock-me
+quarkus.rest-client."quarkus-client".enable-local-proxy=true


### PR DESCRIPTION
**Summary**

This PR addresses #164 by automatically configuring the REST client to use Wiremock in test and dev modes, leveraging the DevServicesRestClientProxyProvider.

**Key Changes:**

- The proxy configuration works even if the original base URL uses TLS.
-  Requires the enable-local-proxy option to be enabled on each REST client instance.
        Note: We might consider adding a global enable-local-proxy toggle on the Quarkus side for better flexibility.
- I am currently exploring a way to enable multi-domain matching (instead of defaulting to localhost), which would significantly reduce the likelihood of collisions.