### PR TITLE
configure rest client to proxy request via wiremock using proxy settings

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -24,12 +24,26 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-spi-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <artifactId>quarkus-rest-deployment</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WiremockStartedBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WiremockStartedBuildItem.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.wiremock.devservice;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final public class WiremockStartedBuildItem extends SimpleBuildItem {
+
+}

--- a/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockRestClientTest.java
+++ b/deployment/src/test/java/io/quarkiverse/wiremock/devservice/WireMockRestClientTest.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.wiremock.devservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class WireMockRestClientTest {
+
+    private static final String APP_PROPERTIES = "application.properties";
+
+    @RegisterExtension
+    static final QuarkusUnitTest UNIT_TEST = new QuarkusUnitTest().withConfigurationResource(APP_PROPERTIES)
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class).addClass(QuarkusClient.class));
+
+    @Inject
+    @RestClient
+    QuarkusClient quarkusClient;
+
+    @Test
+    void testWireMockMappingsFolder() {
+
+        QuarkusClient.User result = quarkusClient.test();
+        assertEquals("John Doe", result.name());
+    }
+
+    @Path("/mock-rest-client")
+    @RegisterRestClient(baseUri = "http://imaginary-host.io/", configKey = "quarkus-client")
+    public interface QuarkusClient {
+
+        record User(String name, String email) {
+        }
+
+        @GET
+        @Consumes("application/json")
+        User test();
+    }
+}

--- a/deployment/src/test/resources/mappings/rest-client.json
+++ b/deployment/src/test/resources/mappings/rest-client.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/mock-rest-client"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "name": "John Doe",
+      "email": "john.doe@quarkus.io"
+    }
+  }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -11,11 +11,15 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.wiremock</groupId>

--- a/integration-tests/src/main/java/io/quarkiverse/wiremock/devservice/QuarkusClient.java
+++ b/integration-tests/src/main/java/io/quarkiverse/wiremock/devservice/QuarkusClient.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.wiremock.devservice;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/mock-rest-client")
+@RegisterRestClient(baseUri = "https://imaginary-host.io/", configKey = "quarkus-client")
+public interface QuarkusClient {
+
+    record User(String name, String email) {
+    }
+
+    @GET
+    @Consumes("application/json")
+    User test();
+}

--- a/integration-tests/src/test/java/io/quarkiverse/wiremock/devservice/WiremockRestClientTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/wiremock/devservice/WiremockRestClientTest.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.wiremock.devservice;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@ConnectWireMock
+@QuarkusTest
+public class WiremockRestClientTest {
+
+    @Inject
+    @RestClient
+    QuarkusClient quarkusClient;
+    WireMock wiremock;
+
+    @Test
+    void testWireMockRestClientProxy() {
+        wiremock.register(get(urlEqualTo("/mock-rest-client"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"name\": \"John Doe\", \"email\": \"john.doe@quarkus.io\"}")));
+        QuarkusClient.User result = quarkusClient.test();
+        assertEquals("John Doe", result.name());
+    }
+}

--- a/integration-tests/src/test/resources/application.properties
+++ b/integration-tests/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 custom.config.wiremock.url=http://localhost:${quarkus.wiremock.devservices.port}/mock-me
+quarkus.rest-client."quarkus-client".enable-local-proxy=true

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.8.5</quarkus.version>
+        <quarkus.version>3.15.1</quarkus.version>
         <wiremock.version>3.6.0</wiremock.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
Fix #164 
this is an alternative implementation to proxy rest client request via wiremock.

I am not sure what option works best for now.

Pros:
- With this solution, the enable-local-proxy option does not need to be enabled on the rest client side which is pretty handy.
Cons:
- with this solution I noticed some issues with https