### PR TITLE
chore(deps): update to Quarkus 3.15.x LTS version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,8 @@ updates:
     ignore:
       - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"
       - dependency-name: "io.quarkus:quarkus-bom"
-        # Stay on Quarkus 3.8.x LTS stream
-        versions: [ ">= 3.9.0" ]
+        # Stay on Quarkus 3.15.x LTS stream
+        versions: [ ">= 3.16.0" ]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Quarkus [WireMock](https://wiremock.org) extension for tests and local developme
 Currently, this Quarkus extension supports the `LTS` streams of Quarkus only. 
 However, it's most likely that this extension will work with the latest and greatest version of `Quarkus` as well.
 
-| Quarkus WireMock | WireMock | Quarkus Platform  | Documentation                                                                                                       |
-|------------------|----------|-------------------|---------------------------------------------------------------------------------------------------------------------|
-| 1.x.x            | 3.x      | 3.8.x (LTS) | [Quarkiverse Docs](https://quarkiverse.github.io/quarkiverse-docs/quarkus-wiremock/dev/index.html) |
+| Quarkus WireMock | WireMock | Quarkus Platform | Documentation                                                                                                       |
+|------------------|----------|------------------|---------------------------------------------------------------------------------------------------------------------|
+| 1.x.x            | 3.x      | 3.15.x (LTS)     | [Quarkiverse Docs](https://quarkiverse.github.io/quarkiverse-docs/quarkus-wiremock/dev/index.html) |
 
 ## 🚀 Quarkus WireMock Extension in Action
 

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
+            <artifactId>quarkus-rest-deployment</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/docs/modules/ROOT/pages/includes/quarkus-wiremock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-wiremock.adoc
@@ -1,0 +1,120 @@
+:summaryTableId: quarkus-wiremock_quarkus-wiremock
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-enabled]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-enabled[`quarkus.wiremock.devservices.enabled`]##
+
+[.description]
+--
+If Dev Services for WireMock has been explicitly enabled or disabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-reload]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-reload[`quarkus.wiremock.devservices.reload`]##
+
+[.description]
+--
+Restart WireMock Dev Service whenever Quarkus is reloaded. Otherwise, whenever files are changed in the `files-mapping` location you would need to restart the Dev Service (WireMock server) manually.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_RELOAD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_RELOAD+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-port]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-port[`quarkus.wiremock.devservices.port`]##
+
+[.description]
+--
+Optional fixed port the WireMock Dev Service will listen to. If not defined, the port will be chosen randomly.
+
+*WARNING:* Only ports between 1025 and 65535 are permitted.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-files-mapping]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-files-mapping[`quarkus.wiremock.devservices.files-mapping`]##
+
+[.description]
+--
+Path to the WireMock configuration files (root dir which contains the `mappings` and `__files` folders). If this starts with `classpath:` then files will be looked up on the classpath instead of the filesystem.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_FILES_MAPPING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_FILES_MAPPING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`src/test/resources`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-global-response-templating]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-global-response-templating[`quarkus.wiremock.devservices.global-response-templating`]##
+
+[.description]
+--
+Response templating is enabled by default in WireMock 3, with this setting response templating can be enabled globally.
+
+Please refer to link:https://wiremock.org/3.x/docs/response-templating/[Response Templating] for more details.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_GLOBAL_RESPONSE_TEMPLATING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_GLOBAL_RESPONSE_TEMPLATING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-extension-scanning-enabled]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-extension-scanning-enabled[`quarkus.wiremock.devservices.extension-scanning-enabled`]##
+
+[.description]
+--
+Control whether WireMock Extension link:https://wiremock.org/docs/extending-wiremock/#extension-registration-via-service-loading[service loading], is enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_EXTENSION_SCANNING_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_EXTENSION_SCANNING_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+|===
+
+
+:!summaryTableId:

--- a/docs/modules/ROOT/pages/includes/quarkus-wiremock_quarkus.wiremock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-wiremock_quarkus.wiremock.adoc
@@ -1,0 +1,120 @@
+:summaryTableId: quarkus-wiremock_quarkus-wiremock
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
+
+h|[.header-title]##Configuration property##
+h|Type
+h|Default
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-enabled]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-enabled[`quarkus.wiremock.devservices.enabled`]##
+
+[.description]
+--
+If Dev Services for WireMock has been explicitly enabled or disabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-reload]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-reload[`quarkus.wiremock.devservices.reload`]##
+
+[.description]
+--
+Restart WireMock Dev Service whenever Quarkus is reloaded. Otherwise, whenever files are changed in the `files-mapping` location you would need to restart the Dev Service (WireMock server) manually.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_RELOAD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_RELOAD+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-port]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-port[`quarkus.wiremock.devservices.port`]##
+
+[.description]
+--
+Optional fixed port the WireMock Dev Service will listen to. If not defined, the port will be chosen randomly.
+
+*WARNING:* Only ports between 1025 and 65535 are permitted.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-files-mapping]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-files-mapping[`quarkus.wiremock.devservices.files-mapping`]##
+
+[.description]
+--
+Path to the WireMock configuration files (root dir which contains the `mappings` and `__files` folders). If this starts with `classpath:` then files will be looked up on the classpath instead of the filesystem.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_FILES_MAPPING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_FILES_MAPPING+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`src/test/resources`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-global-response-templating]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-global-response-templating[`quarkus.wiremock.devservices.global-response-templating`]##
+
+[.description]
+--
+Response templating is enabled by default in WireMock 3, with this setting response templating can be enabled globally.
+
+Please refer to link:https://wiremock.org/3.x/docs/response-templating/[Response Templating] for more details.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_GLOBAL_RESPONSE_TEMPLATING+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_GLOBAL_RESPONSE_TEMPLATING+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-wiremock_quarkus-wiremock-devservices-extension-scanning-enabled]] [.property-path]##link:#quarkus-wiremock_quarkus-wiremock-devservices-extension-scanning-enabled[`quarkus.wiremock.devservices.extension-scanning-enabled`]##
+
+[.description]
+--
+Control whether WireMock Extension link:https://wiremock.org/docs/extending-wiremock/#extension-registration-via-service-loading[service loading], is enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WIREMOCK_DEVSERVICES_EXTENSION_SCANNING_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WIREMOCK_DEVSERVICES_EXTENSION_SCANNING_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+|===
+
+
+:!summaryTableId:

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -35,6 +35,14 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-config-doc-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <targetDirectory>${project.basedir}/modules/ROOT/pages/includes/</targetDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>it.ozimov</groupId>
                 <artifactId>yaml-properties-maven-plugin</artifactId>
                 <executions>
@@ -63,11 +71,6 @@
                         <configuration>
                             <outputDirectory>${project.basedir}/modules/ROOT/pages/includes/</outputDirectory>
                             <resources>
-                                <resource>
-                                    <directory>${project.basedir}/../target/asciidoc/generated/config/</directory>
-                                    <include>quarkus-wiremock-devservices.adoc</include>
-                                    <filtering>false</filtering>
-                                </resource>
                                 <resource>
                                     <directory>${project.basedir}/templates/includes</directory>
                                     <include>attributes.adoc</include>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -11,11 +11,11 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.wiremock</groupId>
@@ -101,7 +101,8 @@
                 </plugins>
             </build>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+                <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.8.5</quarkus.version>
+        <quarkus.version>3.15.1</quarkus.version>
         <wiremock.version>3.6.0</wiremock.version>
     </properties>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
                     <artifactId>quarkus-maven-plugin</artifactId>
                     <version>${quarkus.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-config-doc-maven-plugin</artifactId>
+                    <version>${quarkus.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Leveraged `quarkus update` to migrate the project to the latest version of the Quarkus LTS

The most notable change is the relocation of the rest modules