### PR TITLE
Use moving tag for dcarbone/install-yq-action

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Install yq
-        uses: dcarbone/install-yq-action@v1.2.0
+        uses: dcarbone/install-yq-action@v1
 
       - name: Set up Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
Leverage a moving tag for the action dcarbone/install-yq-action like we do for all other actions.