### PR TITLE
fix: correct port mapping used in WireMock verify call

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/wiremock/devservice/WireMockDevServiceBasicIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/wiremock/devservice/WireMockDevServiceBasicIT.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.wiremock.devservice;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.FILES_MAPPING;
 import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
+import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,6 +63,13 @@ class WireMockDevServiceBasicIT {
     void testNonPropagatedConfigsArentAccessibleInIT() {
         assertThrows(NoSuchElementException.class,
                 () -> ConfigProvider.getConfig().getValue(FILES_MAPPING, String.class));
+    }
+
+    @Test
+    void testPortMappingWithVerify() {
+        var port = Integer.parseInt(devServicesContext.devServicesProperties().get(PORT));
+        given().when().get(String.format("http://localhost:%d/", port));
+        WireMock.verify(1, anyRequestedFor(anyUrl()));
     }
 
     private static boolean isInUse(int port) {

--- a/test/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerConnector.java
+++ b/test/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerConnector.java
@@ -39,6 +39,7 @@ public class WireMockServerConnector
         try {
             int port = Integer.parseInt(devContext.get(PORT));
             wiremock = new WireMock(port);
+            WireMock.configureFor(port);
             wiremock.getGlobalSettings(); // establish a connection to WireMock server eagerly
         } catch (Exception ex) {
             Log.error("Cannot connect to WireMock server!", ex);


### PR DESCRIPTION
This pull request addresses and fixes the problem described in [issue #206](https://github.com/quarkiverse/quarkus-wiremock/issues/206).