### PR TITLE
Ensure that the extension works with Quarkus 3.25+

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerProcessor.java
@@ -81,7 +81,7 @@ class WireMockServerProcessor {
     @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class })
     @Consume(DevServicesResultBuildItem.class)
     DevServiceDescriptionBuildItem renderDevServiceDevUICard() {
-        return new DevServiceDescriptionBuildItem(DEV_SERVICE_NAME, null, devService.getConfig());
+        return new DevServiceDescriptionBuildItem(DEV_SERVICE_NAME, null, null, devService.getConfig());
     }
 
     @BuildStep(onlyIf = { WireMockServerEnabled.class, GlobalDevServicesConfig.Enabled.class, IsDevelopment.class })


### PR DESCRIPTION
Unfortunately we inadvertently [broke](https://github.com/quarkusio/quarkus/pull/48445/files#r2194350794) binary the compatibility of `DevServiceDescriptionBuildItem` 

Relates to: https://github.com/quarkiverse/quarkus-langchain4j/issues/1594