### PR TITLE
Add @ConnectWireMock support for redirecting REST clients to WireMock

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -34,7 +34,7 @@ quarkus.wiremock.devservices.global-response-templating=false
 
 IMPORTANT: Due to its build time nature is totally fine that Quarkus prints `unrecognized configuration key` warnings when executing integration tests.
 
-TIP: Starting the WireMock `Dev Service` doesn't automatically redirect your `@RestClient` calls to it; see xref:_redirecting_rest_clients_to_wiremock[Redirecting REST Clients to WireMock] below.
+TIP: Starting the WireMock `Dev Service` doesn't automatically redirect your `@RestClient` calls to it; see xref:redirecting-rest-clients-to-wiremock[Redirecting REST Clients to WireMock] below.
 
 == Testing
 
@@ -104,7 +104,7 @@ class WireMockDevServiceResourceTest {
         wiremock.register(get(urlEqualTo("/mock-me"))
             .willReturn(aResponse().withStatus(200).withBody(MOCK_MSG)));
 
-        assertEquals(MOCK_MSG, myApiClient.hello()); // <3> gets routed to WireMock automatically
+        assertEquals(MOCK_MSG, myApiClient.hello()); // <3>
     }
 
 }

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -34,6 +34,8 @@ quarkus.wiremock.devservices.global-response-templating=false
 
 IMPORTANT: Due to its build time nature is totally fine that Quarkus prints `unrecognized configuration key` warnings when executing integration tests.
 
+TIP: Starting the WireMock `Dev Service` doesn't automatically redirect your `@RestClient` calls to it; see xref:_redirecting_rest_clients_to_wiremock[Redirecting REST Clients to WireMock] below.
+
 == Testing
 
 === Stubbing & Verifying
@@ -76,6 +78,60 @@ class WireMockDevServiceResourceTest {
 ----
 
 TIP: For more details please refer to the WireMock https://wiremock.org/docs/stubbing/[Stubbing & Verifying] docs.
+
+=== Redirecting REST Clients to WireMock
+
+By default, starting the `WireMock` server does *not* rewire your application's outgoing calls to go through it.
+If you're using a MicroProfile/Quarkus `@RestClient`, you still need to point its base URL at the WireMock `Dev Service` for your requests to actually reach it and match your stubs.
+
+The easiest way is to set the `restClient` attribute of `@ConnectWireMock`:
+
+[source,java]
+----
+@QuarkusTest
+@ConnectWireMock(restClient = "my-api") // <1>
+class WireMockDevServiceResourceTest {
+
+    private static final String MOCK_MSG = "Hello from WireMock!";
+
+    WireMock wiremock;
+
+    @RestClient
+    MyApiClient myApiClient; // <2>
+
+    @Test
+    void testHelloEndpoint() {
+        wiremock.register(get(urlEqualTo("/mock-me"))
+            .willReturn(aResponse().withStatus(200).withBody(MOCK_MSG)));
+
+        assertEquals(MOCK_MSG, myApiClient.hello()); // <3> gets routed to WireMock automatically
+    }
+
+}
+----
+<1> `my-api` must match the configured name of your REST client (i.e. as used in `quarkus.rest-client.my-api.url`, or the client's `@RegisterRestClient(configKey = "my-api")`).
+<2> No manual configuration needed: the client's base URL is redirected to WireMock automatically for the duration of the test.
+<3> Requests now reach WireMock instead of the real downstream API, so your registered stubs get matched.
+
+`restClient` is left empty by default, since an application can have multiple REST clients and only some of them may need to be redirected to WireMock in a given test.
+`@ConnectWireMock` is repeatable, so redirect more than one REST client by repeating it:
+
+[source,java]
+----
+@QuarkusTest
+@ConnectWireMock(restClient = "my-api")
+@ConnectWireMock(restClient = "my-other-api")
+class WireMockDevServiceResourceTest {
+    ...
+}
+----
+
+If you'd rather configure this yourself (e.g. you need more control, or you're not using `@ConnectWireMock`), you can set the client's URL manually, typically in a test-only properties file (e.g. `src/test/resources/application.properties`):
+
+[source,properties]
+----
+quarkus.rest-client.my-api.url=http://localhost:${quarkus.wiremock.devservices.port}
+----
 
 === Configuration retrieval
 

--- a/integration-tests/src/main/java/io/quarkiverse/wiremock/devservice/FarewellApiClient.java
+++ b/integration-tests/src/main/java/io/quarkiverse/wiremock/devservice/FarewellApiClient.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.wiremock.devservice;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "farewell-api", baseUri = "https://production.example.com")
+public interface FarewellApiClient {
+
+    @GET
+    @Path("/mock-me-too")
+    String farewell();
+}

--- a/integration-tests/src/main/java/io/quarkiverse/wiremock/devservice/GreetingApiClient.java
+++ b/integration-tests/src/main/java/io/quarkiverse/wiremock/devservice/GreetingApiClient.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.wiremock.devservice;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "greeting-api", baseUri = "https://production.example.com")
+public interface GreetingApiClient {
+
+    @GET
+    @Path("/mock-me")
+    String greet();
+}

--- a/integration-tests/src/test/java/io/quarkiverse/wiremock/devservice/WireMockRestClientRedirectTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/wiremock/devservice/WireMockRestClientRedirectTest.java
@@ -1,0 +1,43 @@
+package io.quarkiverse.wiremock.devservice;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@ConnectWireMock(restClient = "greeting-api")
+@ConnectWireMock(restClient = "farewell-api")
+class WireMockRestClientRedirectTest {
+
+    private static final String GREETING_MSG = "Hello from WireMock!";
+    private static final String FAREWELL_MSG = "Goodbye from WireMock!";
+
+    WireMock wiremock; // will be injected automatically when the class has been annotated with @ConnectWireMock
+
+    @RestClient
+    GreetingApiClient greetingApiClient;
+
+    @RestClient
+    FarewellApiClient farewellApiClient;
+
+    @Test
+    void testRestClientsAreAutomaticallyRedirectedToWireMock() {
+        Assertions.assertNotNull(wiremock);
+        wiremock.register(get(urlEqualTo("/mock-me")).willReturn(aResponse().withStatus(200).withBody(GREETING_MSG)));
+        wiremock.register(get(urlEqualTo("/mock-me-too")).willReturn(aResponse().withStatus(200).withBody(FAREWELL_MSG)));
+
+        // no manual `quarkus.rest-client.*.url` properties needed: repeating @ConnectWireMock(restClient = "...")
+        // redirects each client's base URL to the WireMock Dev Service for us.
+        Assertions.assertEquals(GREETING_MSG, greetingApiClient.greet());
+        Assertions.assertEquals(FAREWELL_MSG, farewellApiClient.farewell());
+    }
+
+}

--- a/test/src/main/java/io/quarkiverse/wiremock/devservice/ConnectWireMock.java
+++ b/test/src/main/java/io/quarkiverse/wiremock/devservice/ConnectWireMock.java
@@ -2,15 +2,42 @@ package io.quarkiverse.wiremock.devservice;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.QuarkusTestResourceRepeatable;
 
 @QuarkusTestResource(value = WireMockServerConnector.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
+@Repeatable(ConnectWireMock.List.class)
 public @interface ConnectWireMock {
+
+    /**
+     * Name of a configured REST client (as used in the {@code quarkus.rest-client.<name>.url} property) whose base
+     * URL should automatically be redirected to the WireMock {@code Dev Service}.
+     * <p>
+     * Left empty by default, since an application can have multiple REST clients and only some of them may need to
+     * be redirected to WireMock for a given test. Repeat {@code @ConnectWireMock} to redirect more than one REST
+     * client.
+     * <p>
+     * This is a single {@code String} rather than a {@code String[]} on purpose: Quarkus decides whether a test
+     * resource's owning application context can be reused across test classes by comparing the reflected values of
+     * this annotation's attributes, and array-typed attribute values never compare equal in that check (arrays
+     * don't implement {@code equals()}), which would force an application restart between every test class carrying
+     * this annotation.
+     */
+    String restClient() default "";
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @QuarkusTestResourceRepeatable(ConnectWireMock.class)
+    @interface List {
+        ConnectWireMock[] value();
+    }
 }

--- a/test/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerConnector.java
+++ b/test/src/main/java/io/quarkiverse/wiremock/devservice/WireMockServerConnector.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.wiremock.devservice;
 
 import static io.quarkiverse.wiremock.devservice.WireMockConfigKey.PORT;
+import static java.lang.String.format;
 
 import java.util.Collections;
 import java.util.Map;
@@ -14,13 +15,28 @@ import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
 public class WireMockServerConnector
         implements QuarkusTestResourceConfigurableLifecycleManager<ConnectWireMock>, DevServicesContext.ContextAware {
 
+    private static final String REST_CLIENT_URL_PROPERTY = "quarkus.rest-client.%s.url";
+
     WireMock wiremock;
+
+    private String restClient = "";
+    private String baseUrl;
+
+    @Override
+    public void init(ConnectWireMock annotation) {
+        restClient = annotation.restClient();
+    }
 
     @Override
     public Map<String, String> start() {
-        // nothing to do, since the Dev Service has already started the server
-        // and the Dev Service configuration will be propagated by Quarkus automatically.
-        return Collections.emptyMap();
+        // the WireMock server itself is already started by the Dev Service, and its configuration is
+        // propagated by Quarkus automatically; here we only need to redirect the requested REST client, if any.
+        if (restClient.isBlank()) {
+            return Collections.emptyMap();
+        }
+        String property = format(REST_CLIENT_URL_PROPERTY, restClient);
+        Log.debugf("Redirecting REST client [%s] to WireMock via [%s=%s]", restClient, property, baseUrl);
+        return Map.of(property, baseUrl);
     }
 
     @Override
@@ -38,6 +54,7 @@ public class WireMockServerConnector
         final Map<String, String> devContext = context.devServicesProperties();
         try {
             int port = Integer.parseInt(devContext.get(PORT));
+            baseUrl = "http://localhost:" + port;
             wiremock = new WireMock(port);
             WireMock.configureFor(port);
             wiremock.getGlobalSettings(); // establish a connection to WireMock server eagerly


### PR DESCRIPTION
## Summary

Starting the WireMock `Dev Service` via `@ConnectWireMock` doesn't automatically rewire an application's outgoing `@RestClient` calls to go through it — users had to manually redirect each client via a `%test.quarkus.rest-client.<name>.url` property, which wasn't obvious (see [this Zulip thread](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/.E2.9C.94.20WireMock.20for.20Quarkus.20with.20defaults/with/617919596)).

- `@ConnectWireMock` gains a `restClient` attribute that automatically redirects a REST client's base URL to the WireMock Dev Service for the duration of the test.
- `@ConnectWireMock` is now `@Repeatable`, so multiple clients can be redirected by repeating the annotation.
- A single-value `String` attribute is used deliberately rather than `String[]`: Quarkus decides whether a test resource's owning application context can be reused across test classes by comparing the reflected values of the config annotation's attributes, and array-typed values never compare equal in that check (arrays don't implement `equals()`), which would force an application restart between every test class carrying the annotation. This follows Quarkus's own established pattern for custom repeatable test-resource annotations (`@QuarkusTestResourceRepeatable` + nested `List` container).
- Docs updated to lead with this as the primary approach for redirecting REST clients, keeping the manual property as a documented fallback for cases needing more control.

## Test plan

- [x] `WireMockRestClientRedirectTest` added, redirecting two REST clients (`greeting-api`, `farewell-api`) via two repeated `@ConnectWireMock` annotations and asserting both requests are matched by WireMock stubs instead of hitting the clients' real (unreachable) base URI.
- [x] Full existing test suite (`deployment`, `test`, `integration-tests` modules) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)